### PR TITLE
refactor: remove dead URL fetch path; promote bookmarklet

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,13 +160,7 @@
     font-size: 12px; min-height: 16px; margin-top: 6px;
     padding: 0 2px; line-height: 1.4; transition: color 0.15s;
   }
-  #input-hint.url  { color: #1a7c3e; }
   #input-hint.table { color: #555; }
-  #input-hint.cors-error {
-    color: #b22; background: #fff3f3; border: 1px solid #f5c6c6;
-    border-radius: 6px; padding: 8px 10px; margin-top: 8px;
-  }
-  #input-hint.cors-error strong { color: #900; }
 
   #bookmarklet-hint {
     font-size: 12px; color: #666; margin-top: 10px; text-align: center;
@@ -195,16 +189,16 @@
   <div id="input-sheet">
     <div class="drag-hint"></div>
     <h2>Find Your Book</h2>
-    <p>Paste a <strong>catalog URL</strong> (catalog.minlib.net/…) or the <strong>"Where Is It?" table</strong> from the catalog popup.</p>
-    <textarea id="paste-area" placeholder="catalog.minlib.net/GroupedWork/…&#10;&#10;— or —&#10;&#10;Available Copies    Location    Call #&#10;1 of 1     Bedford - Adult    Fiction/VanderMeer&#10;…"></textarea>
+    <div id="bookmarklet-hint">
+      Drag <a id="bookmarklet-link" href="#">MinLibMap Bookmarklet</a> to your bookmarks bar for one-click fetching from any catalog item page.
+    </div>
+    <p>Or paste the <strong>"Where Is It?" table</strong> from the catalog popup.</p>
+    <textarea id="paste-area" placeholder="Available Copies    Location    Call #&#10;1 of 1     Bedford - Adult    Fiction/VanderMeer&#10;…"></textarea>
+    <button id="try-example">Try with example data</button>
     <div id="input-hint"></div>
     <div id="input-actions">
       <button id="cancel-btn">Cancel</button>
       <button id="find-btn">Find My Book</button>
-    </div>
-    <button id="try-example">Try with example data</button>
-    <div id="bookmarklet-hint">
-      Drag <a id="bookmarklet-link" href="#">MinLibMap Bookmarklet</a> to your bookmarks bar for one-click fetching from any catalog item page.
     </div>
   </div>
 </div>
@@ -532,21 +526,6 @@ function showResults(parsed) {
   document.getElementById('results-panel').classList.add('visible');
 }
 
-// ── URL Auto-fetch ──
-const CATALOG_BASE = 'https://catalog.minlib.net';
-// The MLN catalog appends a language suffix to GroupedWork IDs (e.g. "…cc1a-eng").
-const UUID_RE = /GroupedWork\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-[a-z]{3})?)/i;
-const FORMATS_TO_TRY = ['Book', 'Large Print Book', 'Audiobook', 'DVD', 'eBook', 'Music CD', 'Book Club Kit'];
-
-function isCatalogUrl(text) {
-  return /^https?:\/\/catalog\.minlib\.net/i.test(text) || UUID_RE.test(text);
-}
-
-function extractGroupedWorkId(text) {
-  const m = text.match(UUID_RE);
-  return m ? m[1] : null;
-}
-
 // Parse the HTML table that Aspen Discovery returns in its getCopyDetails JSON response.
 // Handles both display style 1 (Available Copies | Location | Call #)
 // and display style 2 (Volume | Location | Call # | Status | …).
@@ -591,33 +570,6 @@ function parseCopyDetailsHtml(html) {
     results.push({ available, total, libraryName, section, callNumber, onShelf: available > 0, library });
   });
   return results;
-}
-
-// Attempt to fetch copy details for a GroupedWork UUID directly from the catalog.
-// Returns { data: parsed[], source: 'auto'|'cors-blocked'|'not-found' }.
-// The catalog returns a valid response (status 200) but does not set CORS headers,
-// so the browser blocks cross-origin reads. Cloudflare also blocks datacenter IPs,
-// ruling out CORS proxies. The caller must handle 'cors-blocked' by falling back
-// to manual paste.
-async function fetchAvailability(uuid) {
-  for (const format of FORMATS_TO_TRY) {
-    const url = `${CATALOG_BASE}/GroupedWork/AJAX?method=getCopyDetails` +
-                `&id=${uuid}&recordId=${uuid}&format=${encodeURIComponent(format)}`;
-    try {
-      const resp = await fetch(url, { mode: 'cors', credentials: 'include' });
-      if (!resp.ok) continue;
-      const json = await resp.json();
-      if (!json.modalBody || /unable to find/i.test(json.modalBody)) continue;
-      const parsed = parseCopyDetailsHtml(json.modalBody);
-      if (parsed.length > 0) return { data: parsed, source: 'auto' };
-    } catch (e) {
-      // TypeError means CORS block — proxies also fail (Cloudflare blocks datacenter
-      // IPs). Return immediately; no point trying other formats.
-      if (e instanceof TypeError) return { data: null, source: 'cors-blocked' };
-      // Other errors (e.g. JSON parse failure): continue to next format.
-    }
-  }
-  return { data: null, source: 'not-found' };
 }
 
 // ── Toast ──
@@ -690,11 +642,7 @@ async function init() {
   // Real-time input type detection badge
   pasteArea.addEventListener('input', () => {
     const val = pasteArea.value.trim();
-    if (!val) { inputHint.textContent = ''; inputHint.className = ''; return; }
-    if (isCatalogUrl(val)) {
-      inputHint.textContent = 'Catalog URL detected — will attempt auto-fetch';
-      inputHint.className = 'url';
-    } else if (/\d+\s+of\s+\d+/.test(val)) {
+    if (/\d+\s+of\s+\d+/.test(val)) {
       inputHint.textContent = 'Table format detected — ready to parse';
       inputHint.className = 'table';
     } else {
@@ -725,61 +673,19 @@ async function init() {
   // Find My Book
   findBtn.addEventListener('click', async () => {
     const text = pasteArea.value.trim();
-    if (!text) { showToast('Please paste a catalog URL or availability data'); return; }
+    if (!text) { showToast('Please paste availability data'); return; }
 
     findBtn.disabled = true;
     inputHint.textContent = '';
     inputHint.className = '';
 
-    let parsed = null;
-
-    if (isCatalogUrl(text)) {
-      // ── URL path: attempt auto-fetch ──
-      const uuid = extractGroupedWorkId(text);
-      if (!uuid) {
-        showToast('Could not find a GroupedWork ID in that URL. Try pasting the full item page URL.');
-        findBtn.disabled = false;
-        return;
-      }
-
-      findBtn.innerHTML = '<span class="spinner"></span>Fetching…';
-      const result = await fetchAvailability(uuid);
-
-      if (result.source === 'auto' && result.data.length > 0) {
-        parsed = result.data;
-
-      } else if (result.source === 'cors-blocked') {
-        // CORS fallback: guide user to manual paste
-        inputHint.className = 'cors-error';
-        inputHint.innerHTML =
-          `<strong>Auto-fetch blocked</strong> by browser security. ` +
-          `Use the <strong>bookmarklet</strong> (below) for one-click fetching, ` +
-          `or visit the catalog link, click <strong>"Where Is It?"</strong>, ` +
-          `select all text in the popup, and paste it here instead.`;
-        pasteArea.value = '';
-        pasteArea.placeholder = 'Paste the "Where Is It?" table text here…';
-        pasteArea.focus();
-        findBtn.disabled = false;
-        findBtn.textContent = 'Find My Book';
-        return;
-
-      } else {
-        showToast('No availability data found for that URL. Try a different format or paste manually.');
-        findBtn.disabled = false;
-        findBtn.textContent = 'Find My Book';
-        return;
-      }
-
-    } else {
-      // ── Paste path: parse table text ──
-      findBtn.innerHTML = '<span class="spinner"></span>Parsing…';
-      parsed = parseAvailability(text);
-      if (parsed.length === 0) {
-        showToast('Could not parse availability data. Make sure you copied from the "Where is it?" popup.');
-        findBtn.disabled = false;
-        findBtn.textContent = 'Find My Book';
-        return;
-      }
+    findBtn.innerHTML = '<span class="spinner"></span>Parsing…';
+    const parsed = parseAvailability(text);
+    if (parsed.length === 0) {
+      showToast('Could not parse availability data. Make sure you copied from the "Where is it?" popup.');
+      findBtn.disabled = false;
+      findBtn.textContent = 'Find My Book';
+      return;
     }
 
     // Log unmatched branches to console for debugging (see issue #4)


### PR DESCRIPTION
Follows up on the bookmarklet work already merged in #6. Removes all code that is permanently unreachable.

## What changed

- `fetchAvailability`, `isCatalogUrl`, `extractGroupedWorkId`, `CATALOG_BASE`, `UUID_RE`, `FORMATS_TO_TRY` removed — the catalog returns a valid 200 response but no CORS headers, and Cloudflare blocks all datacenter proxy IPs, so cross-origin auto-fetch is not viable from a static hosted tool
- CSS dead rules (`.url`, `.cors-error`) removed
- Bookmarklet drag link promoted to first position in the input sheet
- "Try with example data" moved to immediately below the textarea
- Catalog URL mention removed from instructions and placeholder text

Closes #5