### PR TITLE
Fix Get Directions link color in popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
   .popup-avail { color: #1a7c3e; font-weight: 600; }
   .popup-avail.out { color: #b22; }
   .popup-call { color: #666; font-size: 13px; }
-  .popup-directions {
+  .leaflet-popup-content .popup-directions {
     display: inline-block; margin-top: 8px; padding: 6px 14px;
     background: #1a7c3e; color: #fff; border-radius: 6px;
     text-decoration: none; font-size: 13px; font-weight: 600;

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
     background: #1a7c3e; color: #fff; border-radius: 6px;
     text-decoration: none; font-size: 13px; font-weight: 600;
   }
+  .leaflet-popup-content .popup-directions:hover { background: #14612f; }
 
   /* Pulsing user dot */
   @keyframes pulse { 0%,100% { transform: scale(1); opacity: 0.7; } 50% { transform: scale(2.2); opacity: 0; } }


### PR DESCRIPTION
Closes #10.

## What changed

Scoped `.popup-directions` to `.leaflet-popup-content .popup-directions`. Leaflet's own anchor styles were winning the specificity battle, rendering the button text in browser-default blue against the green background. The extra parent class gives our `color: #fff` enough specificity to apply.

## Test plan

- [x] Open index.html, load example data, click a result marker
- [x] Confirm "Get Directions" appears as white text on a green button, not a blue link