### PR TITLE
Expand bookmarklet format list to cover non-book formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,7 +659,7 @@ async function init() {
     'var m=location.href.match(/GroupedWork\\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-[a-z]{3})?)/i);' +
     'if(!m){alert(\'Open a catalog item page first\');return;}' +
     'var id=m[1],' +
-    'fmts=[\'Book\',\'Large Print Book\',\'Audiobook\',\'DVD\',\'eBook\',\'Music CD\',\'Book Club Kit\'],' +
+    'fmts=[\'Book\',\'Large Print Book\',\'Large Print\',\'Braille\',\'Audiobook\',\'Spoken CD\',\'DVD\',\'Blu-ray\',\'DVD or VCD\',\'eBook\',\'Music CD\',\'Book Club Kit\',\'Playaway Audiobook\',\'Console Game\',\'3-D Object\'],' +
     'base=\'https://catalog.minlib.net\',' +
     'target=\'' + bookmarkletTarget + '\';' +
     '(function t(i){' +


### PR DESCRIPTION
Adds missing format strings to the bookmarklet's `fmts` array so the bookmarklet can find availability data for non-book item types. Previously, formats like Playaway Audiobook and Spoken CD were not in the list, causing the bookmarklet to exhaust all options and alert "No availability data found."

New formats added: `Large Print`, `Braille`, `Spoken CD`, `Blu-ray`, `DVD or VCD`, `Playaway Audiobook`, `Console Game`, `3-D Object`.

Closes #14.

## Test plan

- [ ] Open a catalog Playaway Audiobook item and click the bookmarklet — availability data loads instead of "No availability data found"
- [ ] Same for a Spoken CD item
- [ ] Book items still work (Book is still first in the list)