### PR TITLE
Add format filter checkboxes to results panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,14 @@
     padding: 6px 14px; font-size: 13px; color: #555; cursor: pointer;
   }
   #clear-btn:hover { background: #f5f5f5; }
+  #format-filter {
+    display: flex; flex-wrap: wrap; gap: 6px 12px;
+    padding: 0 16px 8px; flex-shrink: 0;
+  }
+  #format-filter label {
+    display: flex; align-items: center; gap: 4px;
+    font-size: 13px; color: #333; cursor: pointer; white-space: nowrap;
+  }
   #results-status {
     padding: 0 16px 8px; font-size: 13px; color: #666; flex-shrink: 0;
   }
@@ -221,6 +229,7 @@
     <h2 id="results-title">Results</h2>
     <button id="clear-btn">Clear</button>
   </div>
+  <div id="format-filter" style="display:none"></div>
   <div id="results-status"></div>
   <div id="results-list"></div>
 </div>
@@ -314,6 +323,7 @@ const EXAMPLE_DATA = `Available Copies\tLocation\tCall #
 
 // ── Globals ──
 let map, userLatLng = null, allMarkers = {}, resultMarkers = [], userMarker = null;
+let allParsed = [];
 
 // ── Init Map ──
 function initMap() {
@@ -451,6 +461,26 @@ function groupByLibrary(rows) {
 
 // ── Display Results ──
 function showResults(parsed) {
+  allParsed = parsed;
+
+  const formatFilter = document.getElementById('format-filter');
+  const formats = [...new Set(parsed.map(r => r.format).filter(Boolean))];
+  if (formats.length > 1) {
+    formatFilter.innerHTML = formats.map(f =>
+      `<label><input type="checkbox" value="${f}" checked> ${f}</label>`
+    ).join('');
+    formatFilter.style.display = 'flex';
+  } else {
+    formatFilter.style.display = 'none';
+  }
+
+  renderResults(parsed);
+
+  document.getElementById('bottom-bar').style.display = 'none';
+  document.getElementById('results-panel').classList.add('visible');
+}
+
+function renderResults(rows) {
   // Clear old result markers
   resultMarkers.forEach(m => map.removeLayer(m));
   resultMarkers = [];
@@ -459,7 +489,7 @@ function showResults(parsed) {
   Object.values(allMarkers).forEach(m => m.setStyle({ fillColor: '#aaa', color: '#888', radius: 5, fillOpacity: 0.5 }));
 
   // Group by library, then compute distances
-  const grouped = groupByLibrary(parsed);
+  const grouped = groupByLibrary(rows);
   grouped.forEach(r => {
     if (r.library && userLatLng) {
       r.distance = distanceMiles(userLatLng.lat, userLatLng.lng, r.library.lat, r.library.lng);
@@ -569,10 +599,6 @@ function showResults(parsed) {
 
     resultsList.appendChild(row);
   });
-
-  // Show results panel, hide bottom bar
-  document.getElementById('bottom-bar').style.display = 'none';
-  document.getElementById('results-panel').classList.add('visible');
 }
 
 // Parse the HTML table that Aspen Discovery returns in its getCopyDetails JSON response.
@@ -701,6 +727,11 @@ async function init() {
   const findBtn = document.getElementById('find-btn');
   const resultsPanel = document.getElementById('results-panel');
 
+  document.getElementById('format-filter').addEventListener('change', () => {
+    const checked = [...document.querySelectorAll('#format-filter input:checked')].map(cb => cb.value);
+    renderResults(allParsed.filter(r => !r.format || checked.includes(r.format)));
+  });
+
   const inputHint = document.getElementById('input-hint');
 
   // Real-time input type detection badge
@@ -777,6 +808,8 @@ async function init() {
   document.getElementById('clear-btn').addEventListener('click', () => {
     resultsPanel.classList.remove('visible');
     bottomBar.style.display = 'flex';
+    allParsed = [];
+    document.getElementById('format-filter').style.display = 'none';
     pasteArea.value = '';
 
     // Reset markers


### PR DESCRIPTION
Fixes #24.

When a grouped work returns copies in more than one format, a row of checkboxes appears between the results header and the location count — one checkbox per format, all checked by default. Unchecking a format removes its copies from the map markers, on-shelf count, and result list; re-checking restores them. Any combination is valid.

The render logic is extracted from `showResults` into `renderResults(rows)` so the initial display and each checkbox change can both invoke it with the appropriate subset of `allParsed` without duplicating code. The filter bar is hidden and `allParsed` is reset when the user clears results.

Items fetched via the old single-format bookmarklet (where `r.format` is null) are always included regardless of checkbox state, so nothing breaks for existing users.

## Test plan

- [ ] Load a single-format item — confirm no checkboxes appear.
- [ ] Load a multi-format item (Book + Braille, or similar) — confirm one checkbox per format, all checked, combined results shown.
- [ ] Uncheck one format — confirm its locations disappear from the list and map markers update.
- [ ] Re-check it — confirm locations reappear.
- [ ] Uncheck all — confirm list is empty and all markers reset to gray.
- [ ] Clear results — confirm checkboxes are gone on next search.