### PR TITLE
Format filter: count-based formats, add Check All / Clear All

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,11 @@
     display: flex; align-items: center; gap: 4px;
     font-size: 13px; color: #333; cursor: pointer; white-space: nowrap;
   }
+  .filter-ctrl {
+    font-size: 12px; color: #1a7c3e; background: none; border: none;
+    padding: 0; cursor: pointer; text-decoration: underline; white-space: nowrap;
+  }
+  .filter-ctrl:hover { color: #14612f; }
   #results-status {
     padding: 0 16px 8px; font-size: 13px; color: #666; flex-shrink: 0;
   }
@@ -464,11 +469,13 @@ function showResults(parsed) {
   allParsed = parsed;
 
   const formatFilter = document.getElementById('format-filter');
-  const formats = [...new Set(parsed.map(r => r.format).filter(Boolean))];
+  const formatCounts = parsed.reduce((acc, r) => { if (r.format) acc[r.format] = (acc[r.format] || 0) + 1; return acc; }, {});
+  const formats = Object.keys(formatCounts);
   if (formats.length > 1) {
-    formatFilter.innerHTML = formats.map(f =>
-      `<label><input type="checkbox" value="${f}" checked> ${f}</label>`
-    ).join('');
+    formatFilter.innerHTML =
+      '<button class="filter-ctrl" id="check-all-btn">Check all</button>' +
+      '<button class="filter-ctrl" id="clear-all-btn">Clear all</button>' +
+      formats.map(f => `<label><input type="checkbox" value="${f}" checked> ${f}</label>`).join('');
     formatFilter.style.display = 'flex';
   } else {
     formatFilter.style.display = 'none';
@@ -730,6 +737,16 @@ async function init() {
   document.getElementById('format-filter').addEventListener('change', () => {
     const checked = [...document.querySelectorAll('#format-filter input:checked')].map(cb => cb.value);
     renderResults(allParsed.filter(r => !r.format || checked.includes(r.format)));
+  });
+
+  document.getElementById('format-filter').addEventListener('click', e => {
+    if (e.target.id === 'check-all-btn') {
+      document.querySelectorAll('#format-filter input').forEach(cb => cb.checked = true);
+      renderResults(allParsed);
+    } else if (e.target.id === 'clear-all-btn') {
+      document.querySelectorAll('#format-filter input').forEach(cb => cb.checked = false);
+      renderResults([]);
+    }
   });
 
   const inputHint = document.getElementById('input-hint');


### PR DESCRIPTION
Fixes #26.

Two changes to the format filter bar:

- Formats are now derived by counting rows per format (instead of a Set dedupe), making it explicit that only formats with at least one copy in the results get a checkbox.
- Check All and Clear All buttons appear before the checkboxes when the filter is visible. Check All restores all rows; Clear All blanks the map and list. Both use event delegation on the container so they survive innerHTML rebuilds on each new search.

## Test plan

- [ ] Load a multi-format item — confirm Check All and Clear All appear to the left of the checkboxes.
- [ ] Uncheck a format, then click Check All — confirm all locations reappear.
- [ ] Click Clear All — confirm the list empties and all map markers reset to gray.
- [ ] Reload with a single-format item — confirm no filter bar appears.