### PR TITLE
Deduplicate cross-format rows and trim format list

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,10 +461,17 @@ function groupByLibrary(rows) {
 
 // ── Display Results ──
 function showResults(parsed) {
-  allParsed = parsed;
+  const seen = new Set();
+  const deduped = parsed.filter(r => {
+    const key = `${r.libraryName}|${r.section}|${r.callNumber}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  allParsed = deduped;
 
   const formatFilter = document.getElementById('format-filter');
-  const formats = [...new Set(parsed.map(r => r.format).filter(Boolean))];
+  const formats = [...new Set(deduped.map(r => r.format).filter(Boolean))];
   if (formats.length > 1) {
     formatFilter.innerHTML = formats.map(f =>
       `<label><input type="checkbox" value="${f}" checked> ${f}</label>`
@@ -474,7 +481,7 @@ function showResults(parsed) {
     formatFilter.style.display = 'none';
   }
 
-  renderResults(parsed);
+  renderResults(deduped);
 
   document.getElementById('bottom-bar').style.display = 'none';
   document.getElementById('results-panel').classList.add('visible');
@@ -703,7 +710,7 @@ async function init() {
     'var m=location.href.match(/GroupedWork\\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-[a-z]{3})?)/i);' +
     'if(!m){alert(\'Open a catalog item page first\');return;}' +
     'var id=m[1],' +
-    'fmts=[\'Book\',\'Large Print Book\',\'Large Print\',\'Braille\',\'Audiobook\',\'Spoken CD\',\'DVD\',\'Blu-ray\',\'DVD or VCD\',\'eBook\',\'Music CD\',\'Book Club Kit\',\'Playaway Audiobook\',\'Console Game\',\'3-D Object\'],' +
+    'fmts=[\'Book\',\'Large Print\',\'Spoken CD\',\'Playaway Audiobook\',\'Braille\',\'Blu-ray\',\'DVD or VCD\',\'Music CD\',\'Console Game\',\'3-D Object\'],' +
     'base=\'https://catalog.minlib.net\',' +
     'target=\'' + bookmarkletTarget + '\';' +
     'Promise.all(fmts.map(function(fmt){' +


### PR DESCRIPTION
Fixes #28.

**Deduplication**: rows are filtered by `libraryName|section|callNumber` before being stored in `allParsed`. `Promise.all` returns results in `fmts` array order, so when the catalog echoes the same copy under multiple format queries (e.g. Spoken CD data returned for a Blu-ray request), the copy keeps the label from whichever format appears earlier in the list. Ghost checkboxes for mis-labeled duplicates disappear because those formats end up with zero rows after dedup.

**Format list**: trimmed from 15 to 10 formats and reordered to reflect actual Minuteman holdings. Removed: Large Print Book, Audiobook, DVD, eBook, Book Club Kit.

## Test plan

- [ ] Reinstall the bookmarklet after loading the page.
- [ ] Open a Spoken CD item — confirm only "Spoken CD" appears as a checkbox, not Blu-ray or other duplicates.
- [ ] Open an item with genuine multi-format copies (e.g. Book + Spoken CD) — confirm both checkboxes appear with the correct locations under each.
- [ ] Confirm the 10-format list matches: Book, Large Print, Spoken CD, Playaway Audiobook, Braille, Blu-ray, DVD or VCD, Music CD, Console Game, 3-D Object.