### PR TITLE
Offset flyTo so marker lands at top quarter of viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,10 @@ function showResults(parsed) {
 
     if (r.library) {
       row.addEventListener('click', () => {
-        map.flyTo([r.library.lat, r.library.lng], 15, { duration: 0.8 });
+        const targetPx = map.project([r.library.lat, r.library.lng], 15);
+        const offsetPx = map.getSize().y * 0.25;
+        const adjustedLatLng = map.unproject(targetPx.add([0, offsetPx]), 15);
+        map.flyTo(adjustedLatLng, 15, { duration: 0.8 });
         const marker = allMarkers[r.library.id];
         if (marker) setTimeout(() => marker.openPopup(), 850);
       });


### PR DESCRIPTION
Fixes #31.

When the results panel is open (~55vh), `map.flyTo` was centering the marker at the true viewport center, putting it behind the panel. The fix projects the target to pixels at zoom 15, shifts the fly destination south by 25% of the map height, and unprojects back — so the marker lands at ~25% from the top (center of the visible map area above the panel).

## Test plan
- [ ] Search for a title, click a result row — marker should be visible near the top quarter of the screen, not hidden behind the panel.
- [ ] Verify the popup still opens after the fly animation.
- [ ] Confirm no change in behavior when no results panel is open (clear search, zoom around).