### PR TITLE
Tweak flyTo offset from 0.25 to 0.33

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@ function showResults(parsed) {
     if (r.library) {
       row.addEventListener('click', () => {
         const targetPx = map.project([r.library.lat, r.library.lng], 15);
-        const offsetPx = map.getSize().y * 0.25;
+        const offsetPx = map.getSize().y * 0.33;
         const adjustedLatLng = map.unproject(targetPx.add([0, offsetPx]), 15);
         map.flyTo(adjustedLatLng, 15, { duration: 0.8 });
         const marker = allMarkers[r.library.id];

--- a/index.html
+++ b/index.html
@@ -562,7 +562,7 @@ function showResults(parsed) {
     if (r.library) {
       row.addEventListener('click', () => {
         const targetPx = map.project([r.library.lat, r.library.lng], 15);
-        const offsetPx = map.getSize().y * 0.33;
+        const offsetPx = map.getSize().y * 0.18;
         const adjustedLatLng = map.unproject(targetPx.add([0, offsetPx]), 15);
         map.flyTo(adjustedLatLng, 15, { duration: 0.8 });
         const marker = allMarkers[r.library.id];


### PR DESCRIPTION
Follow-up to #32 / issue #31.

0.25 placed the marker slightly too high on smaller viewports. 0.33 keeps it comfortably above the results panel while sitting closer to the center of the visible area.

## Test plan
- [ ] Search for a title, click a result row — marker should sit clearly in the upper portion of the map, above the results panel.
- [ ] Check on a smaller screen (or narrow browser window) that the marker isn't clipped near the top.