### PR TITLE
Add real iCloud Shortcut ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,8 +681,7 @@ async function init() {
 
   if (isIOS) {
     // On iOS, link to the Shortcuts gallery page instead of a javascript: URI.
-    // Replace SHORTCUT_ID once the Shortcut is created and shared via iCloud.
-    bookmarkletLink.href = 'https://www.icloud.com/shortcuts/SHORTCUT_ID';
+    bookmarkletLink.href = 'https://www.icloud.com/shortcuts/c397d32d0b4847f6a071082b3a5c0c21';
     bookmarkletLink.textContent = 'Add MinLibMap Shortcut';
     bookmarkletHint.firstChild.textContent = 'Tap ';
     bookmarkletHint.lastChild.textContent = ' to add the one-tap shortcut for any catalog page.';


### PR DESCRIPTION
The real Shortcut ID was pushed to the branch after PR #35 had already been merged, so it was dropped. This puts it in.

## Test plan
- [ ] On iPhone, open MinLibMap and tap "Find My Book" — hint should read "Tap [Add MinLibMap Shortcut]..." with a working iCloud link.