### PR TITLE
Fall back to DOM scan for GroupedWork UUID on Record-URL pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -691,7 +691,9 @@ async function init() {
     // any instance — local dev or production — without hardcoding a URL.
     const bookmarkletTarget = location.href.split('#')[0];
     bookmarkletLink.href = 'javascript:(function(){' +
-      'var m=location.href.match(/GroupedWork\\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-[a-z]{3})?)/i);' +
+      'var p=/GroupedWork\\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?:-[a-z]{3})?)/i,' +
+      'm=location.href.match(p);' +
+      'if(!m){var as=document.querySelectorAll(\'a[href*="/GroupedWork/"]\');for(var i=0;i<as.length;i++){m=as[i].href.match(p);if(m)break;}}' +
       'if(!m){alert(\'Open a catalog item page first\');return;}' +
       'var id=m[1],' +
       'base=\'https://catalog.minlib.net\',' +


### PR DESCRIPTION
Closes #37.

## What changed

When the bookmarklet ran on a `Record/.bXXXXXXX` catalog URL, it found no GroupedWork UUID in `location.href` and immediately showed "Open a catalog item page first". The UUID is present in the page DOM (Aspen Discovery renders `<a href="/GroupedWork/UUID">` links on every Record page) but the bookmarklet never looked there.

Added a DOM fallback: if the URL regex fails, scan `document.querySelectorAll('a[href*="/GroupedWork/"]')` and extract the UUID from the first match. No extra network call needed.

## Test plan

- [ ] Bookmarklet on a GroupedWork-URL page still opens the map
- [ ] Bookmarklet on a Record-URL page (e.g., Pokemon Scarlet via search results) now opens the map
- [ ] Bookmarklet on a non-catalog page still alerts "Open a catalog item page first"
- [ ] Confirm on dev preview: esakkas24.github.io/minlibmap_dev