### PR TITLE
Sort and highlight available copies in library popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
   .popup-avail { color: #1a7c3e; font-weight: 600; }
   .popup-avail.out { color: #b22; }
   .popup-call { color: #666; font-size: 13px; }
+  .popup-call.on-shelf { color: #1a7c3e; font-weight: 600; }
   .leaflet-popup-content .popup-directions {
     display: inline-block; margin-top: 8px; padding: 6px 14px;
     background: #1a7c3e; color: #fff; border-radius: 6px;
@@ -503,9 +504,10 @@ function showResults(parsed) {
     if (base) base.setStyle({ fillColor: color, color: isOnShelf ? '#0f5c2a' : '#993333', radius, fillOpacity });
 
     // Add popup
-    const copyLines = r.copies.map(c => {
+    const sortedCopies = [...r.copies].sort((a, b) => (b.available > 0) - (a.available > 0));
+    const copyLines = sortedCopies.map(c => {
       const label = [c.format, c.section, c.callNumber].filter(Boolean).join(' — ');
-      return label ? `<div class="popup-call">${label}</div>` : '';
+      return label ? `<div class="popup-call${c.available > 0 ? ' on-shelf' : ''}">${label}</div>` : '';
     }).join('');
     const popupHtml = `
       <div class="popup-name">${r.library.name}</div>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
   .popup-avail { color: #1a7c3e; font-weight: 600; }
   .popup-avail.out { color: #b22; }
   .popup-call { color: #666; font-size: 13px; }
-  .popup-call.on-shelf { color: #1a7c3e; font-weight: 600; }
+  .popup-call.on-shelf { color: #1a7c3e; }
   .leaflet-popup-content .popup-directions {
     display: inline-block; margin-top: 8px; padding: 6px 14px;
     background: #1a7c3e; color: #fff; border-radius: 6px;


### PR DESCRIPTION
Closes #40.

## What changed

When a library holds multiple copies, the popup now sorts available copies to the top and renders them in green. Unavailable copies follow in the existing grey. The per-copy `available` count was already in `r.copies`; the rendering just wasn't using it.

Two-line change: sort `r.copies` by availability before rendering, then apply `.popup-call.on-shelf` to copies where `available > 0`.

## Test plan

- [ ] Library with one copy: popup unchanged
- [ ] Library with multiple copies, all checked out: all grey, order unchanged
- [ ] Library with multiple copies, some available: available ones appear in green at top, checked-out ones grey below
- [ ] Confirm on dev preview: esakkas24.github.io/minlibmap_dev