### PR TITLE
Fix missing closing div that hid results panel after bookmarklet use

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,7 @@
         <span class="install-step-num">3</span>A map opens showing locations that have the book on-shelf, ordered by distance from you.
       </div>
       <img class="install-screenshot" src="screenshots/instructions3.page.png" alt="MinLibMap results view with pins on map">
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Refs #42.

When the screenshots were added, the closing `</div>` for the third `.install-step` was dropped. The browser parsed `#results-panel` as a descendant of `#install-overlay`, so it was hidden whenever the overlay was not visible — meaning the library list and distances never appeared after using the bookmarklet.

## Test plan

- [ ] Use the bookmarklet on a catalog item page — MinLibMap opens with both the map pins and the results panel visible
- [ ] Open the install instructions modal and close it — results panel is unaffected