### PR TITLE
Add (Instructions) link next to bookmarklet hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,9 @@
   @media (hover: none) {
     #bookmarklet-link { cursor: pointer; }
   }
+  #install-instructions-link {
+    color: #1a7c3e; font-size: 13px; white-space: nowrap;
+  }
 
   /* Bookmarklet install instructions modal */
   #install-overlay {
@@ -243,7 +246,7 @@
     <div class="drag-hint"></div>
     <h2>Find Your Book</h2>
     <div id="bookmarklet-hint">
-      Drag <a id="bookmarklet-link" href="#">MinLibMap</a> to your bookmarks bar for one-click fetching from any catalog item page.
+      Drag <a id="bookmarklet-link" href="#">MinLibMap</a> to your bookmarks bar for one-click fetching from any catalog item page. <a id="install-instructions-link" href="#">(Instructions)</a>
     </div>
     <p class="or-divider"><strong>OR</strong></p>
     <p>Paste the <strong>"Where Is It?"</strong> table from the catalog popup.</p>
@@ -776,6 +779,11 @@ async function init() {
 
     bookmarkletLink.addEventListener('dragstart', () => {
       setTimeout(() => installOverlay.classList.add('visible'), 2000);
+    });
+
+    document.getElementById('install-instructions-link').addEventListener('click', (e) => {
+      e.preventDefault();
+      installOverlay.classList.add('visible');
     });
 
     installClose.addEventListener('click', () => {


### PR DESCRIPTION
Closes #45.

Adds an inline `(Instructions)` link after the bookmarklet hint text. Clicking it opens the same install popup that fires on dragstart. The link and its click listener are set up inside the `else` block (PC path), so it is never rendered or wired on iOS.

## Test plan

- [x] Open the input sheet on desktop — "(Instructions)" appears after the bookmarklet hint text
- [x] Click "(Instructions)" — install popup opens
- [x] Close the popup with X or backdrop click — works as before
- [x] Drag the bookmarklet link — popup still appears after 2s delay as before
- [ ] Open on iOS — hint shows the Shortcuts link with no "(Instructions)" link