### PR TITLE
Add (Instructions) link and update iOS Shortcut URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ async function init() {
 
   if (isIOS) {
     // On iOS, link to the Shortcuts gallery page instead of a javascript: URI.
-    bookmarkletLink.href = 'https://www.icloud.com/shortcuts/c397d32d0b4847f6a071082b3a5c0c21';
+    bookmarkletLink.href = 'https://www.icloud.com/shortcuts/5063221b93374f19918fa1aa986d2f38';
     bookmarkletLink.textContent = 'Add MinLibMap Shortcut';
     bookmarkletHint.firstChild.textContent = 'Tap ';
     bookmarkletHint.lastChild.textContent = ' to add the one-tap shortcut for any catalog page.';


### PR DESCRIPTION
Closes #45, closes #47.

## What changed

- Adds an inline `(Instructions)` link after the bookmarklet hint text on desktop. Clicking it opens the install instructions popup (same one that fires on dragstart). The link is only added in the PC branch so it never appears on iOS.
- Updates the iCloud Shortcuts gallery link for iOS to the new URL.

## Test plan

- [ ] Open the input sheet on desktop — "(Instructions)" appears after the hint text
- [ ] Click "(Instructions)" — install popup opens and closes normally
- [ ] Open on iOS — Shortcuts link points to the new iCloud URL; no "(Instructions)" link visible