### PR TITLE
Remove drag handle from static panels, default results to middle

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,10 @@
   /* Bottom bar - State A */
   #bottom-bar {
     position: fixed; bottom: 0; left: 0; right: 0; z-index: 1000;
-    padding: 0 16px calc(12px + env(safe-area-inset-bottom, 0px));
+    padding: 12px 16px; padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
     background: #fff; border-radius: 16px 16px 0 0;
     box-shadow: 0 -2px 12px rgba(0,0,0,0.1);
-    display: flex; flex-direction: column; align-items: stretch;
-    overflow: hidden; transition: height 0.3s ease;
+    display: flex; align-items: center;
   }
   #paste-btn {
     flex: 1; padding: 14px 20px; border: none; border-radius: 10px;
@@ -245,7 +244,6 @@
   }
   .drag-zone:active { cursor: grabbing; }
   .drag-zone .drag-hint { margin: 0; }
-  #bottom-bar .drag-zone { margin: 0 -16px; }
 </style>
 </head>
 <body>
@@ -253,13 +251,11 @@
 <div id="map"></div>
 
 <div id="bottom-bar">
-  <div class="drag-zone"><div class="drag-hint"></div></div>
   <button id="paste-btn">Find My Book</button>
 </div>
 
 <div id="input-overlay">
   <div id="input-sheet">
-    <div class="drag-hint"></div>
     <h2>Find Your Book</h2>
     <div id="bookmarklet-hint">
       Drag <a id="bookmarklet-link" href="#">MinLibMap</a> to your bookmarks bar for one-click fetching from any catalog item page. <a id="install-instructions-link" href="#">(Instructions)</a>
@@ -430,7 +426,7 @@ const EXAMPLE_DATA = `Available Copies\tLocation\tCall #
 
 // ── Globals ──
 let map, userLatLng = null, allMarkers = {}, resultMarkers = [], userMarker = null;
-let bottomBarDrag, resultsPanelDrag;
+let resultsPanelDrag;
 
 // ── Init Map ──
 function initMap() {
@@ -692,7 +688,6 @@ function showResults(parsed) {
   });
 
   // Show results panel, hide bottom bar
-  bottomBarDrag.reset();
   resultsPanelDrag.reset();
   document.getElementById('bottom-bar').style.display = 'none';
   document.getElementById('results-panel').classList.add('visible');
@@ -887,7 +882,7 @@ async function init() {
     }
 
     function reset() {
-      currentH = getTallH();
+      currentH = Math.min(Math.round(window.innerHeight * 0.55), getTallH());
       panel.style.transition = 'none';
       panel.style.height = `${currentH}px`;
     }
@@ -946,8 +941,6 @@ async function init() {
     return { reset };
   }
 
-  const bottomBarTallH = bottomBar.scrollHeight;
-  bottomBarDrag = makeDraggable(bottomBar, () => bottomBarTallH);
   resultsPanelDrag = makeDraggable(resultsPanel, () => window.innerHeight - sat);
 
   const inputHint = document.getElementById('input-hint');
@@ -1027,7 +1020,6 @@ async function init() {
     resultsPanelDrag.reset();
     resultsPanel.classList.remove('visible');
     bottomBar.style.display = 'flex';
-    bottomBarDrag.reset();
     pasteArea.value = '';
 
     // Reset markers


### PR DESCRIPTION
Follow-up to #55, still under issue #54.

## What changed

- Removed `.drag-zone`/`.drag-hint` from `#bottom-bar` (the initial "Find My Book" button) and from `#input-sheet` (the paste/search panel). Neither is draggable, so the grey pill had no purpose there.
- Restored `#bottom-bar` to its original layout: horizontal flex, no `overflow: hidden`, no height transition.
- Results panel now opens at the middle snap (~55vh) instead of full height when a search completes.

## Test plan

- [x] Load the app — no grey bar visible on the "Find My Book" panel.
- [x] Tap "Find My Book" — no grey bar on the paste/search sheet.
- [x] Run a search — results panel opens at middle height (~55vh), not full screen.
- [x] Drag handle still works on the results panel: tall, middle, and minimized snaps all function correctly.