### PR TITLE
Lock instruction modal header to top while scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,17 +201,23 @@
   #install-overlay.visible { display: flex; }
   #install-modal-ios,
   #install-modal {
-    background: #fff; border-radius: 16px; padding: 24px 20px 20px;
+    background: #fff; border-radius: 16px; padding: 0;
     max-width: 480px; width: 100%; max-height: 90vh; overflow-y: auto;
-    position: relative;
   }
-  #install-modal h2 { font-size: 18px; margin-bottom: 16px; color: #1a1a1a; }
+  .modal-header {
+    position: sticky; top: 0; background: #fff; z-index: 1;
+    border-radius: 16px 16px 0 0;
+    padding: 20px 20px 12px;
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .modal-header h2 { font-size: 18px; color: #1a1a1a; }
+  .modal-body { padding: 0 20px 20px; }
   #install-close-ios,
   #install-close {
-    position: absolute; top: 14px; right: 16px;
     background: none; border: none; font-size: 22px; line-height: 1;
-    cursor: pointer; color: #666; padding: 0 4px;
+    cursor: pointer; color: #666; padding: 0 4px; flex-shrink: 0;
   }
+  #install-close-ios:hover,
   #install-close:hover { color: #1a1a1a; }
   .install-step {
     display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px;
@@ -274,8 +280,11 @@
 
 <div id="install-overlay-ios">
   <div id="install-modal-ios">
-    <button id="install-close-ios" aria-label="Close">&times;</button>
-    <h2>How to use MinLibMap</h2>
+    <div class="modal-header">
+      <h2>How to use MinLibMap</h2>
+      <button id="install-close-ios" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
     <div class="install-step">
       <div class="install-step-label">
         <span class="install-step-num">1</span>Tap "Add MinLibMap Shortcut" then "Add Shortcut" to add the shortcut to your device.
@@ -300,13 +309,17 @@
       </div>
       <img class="install-screenshot" src="screenshots/ios/instructions4.map.png" alt="MinLibMap results view with map pins showing on-shelf locations">
     </div>
+    </div>
   </div>
 </div>
 
 <div id="install-overlay">
   <div id="install-modal">
-    <button id="install-close" aria-label="Close">&times;</button>
-    <h2>How to use MinLibMap</h2>
+    <div class="modal-header">
+      <h2>How to use MinLibMap</h2>
+      <button id="install-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
     <div class="install-step">
       <div class="install-step-label">
         <span class="install-step-num">1</span>Drag the bookmarklet to your bookmarks bar.
@@ -323,6 +336,7 @@
         <span class="install-step-num">3</span>A map opens showing locations that have the book on-shelf, ordered by distance from you.
       </div>
       <img class="install-screenshot" src="screenshots/instructions3.page.png" alt="MinLibMap results view with pins on map">
+    </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #60.

The "How to use MinLibMap" heading and close button previously scrolled away with the content. Wrapped them in a `sticky`-positioned `.modal-header` div so they stay locked to the top of the modal while the steps scroll beneath.

Structural change: padding moved off the modal element itself onto `.modal-header` and a new `.modal-body` wrapper, which is required for `position: sticky` to work correctly inside an `overflow-y: auto` container.

Applies to both the desktop and iOS instruction modals.

## Test plan

- [x] Open Instructions on desktop — header and X stay visible while scrolling
- [x] Open Instructions on iOS — header and X stay visible while scrolling
- [x] Close button still works on both